### PR TITLE
Check utf 8 on string encoding

### DIFF
--- a/lib/protocol_buffers/runtime/field.rb
+++ b/lib/protocol_buffers/runtime/field.rb
@@ -294,16 +294,26 @@ module ProtocolBuffers
 
       def check_value(value)
         if HAS_ENCODING
-          value.valid_encoding? || raise(ArgumentError, "string value is not valid utf-8")
+          value.dup.force_encoding(Encoding::UTF_8).valid_encoding? || raise(ArgumentError, "string value is not valid utf-8")
+        end
+      end
+
+      def serialize(value)
+        check_value(value)
+        if HAS_ENCODING
+          value.dup.force_encoding(Encoding::UTF_8)
+        else
+          value
         end
       end
 
       def deserialize(value)
         read_value = value.read.to_s
         if HAS_ENCODING
-          read_value.force_encoding("utf-8")
+          read_value.force_encoding(Encoding::UTF_8)
+        else
+          read_value
         end
-        read_value
       end
     end
 


### PR DESCRIPTION
Currently strings are checked for utf-8 correctness only on message decoding. It still may happen that a byte string containing non-utf-8 codes is inserted into a string wire when  encoding a message. With this patch such non-utf-8 values are rejected by encoder.
