### PR TITLE
Rename Message#fields

### DIFF
--- a/lib/protocol_buffers/runtime/decoder.rb
+++ b/lib/protocol_buffers/runtime/decoder.rb
@@ -6,7 +6,7 @@ module ProtocolBuffers
 
   module Decoder # :nodoc: all
     def self.decode(io, message)
-      fields = message.fields
+      fields = message.message_fields
 
       until io.eof?
         tag_int = Varint.decode(io)

--- a/lib/protocol_buffers/runtime/encoder.rb
+++ b/lib/protocol_buffers/runtime/encoder.rb
@@ -12,7 +12,7 @@ module ProtocolBuffers
     def self.encode(io, message)
       message.validate!
 
-      message.fields.each do |tag, field|
+      message.message_fields.each do |tag, field|
         next unless message.value_for_tag?(tag)
 
         value = message.value_for_tag(tag)

--- a/lib/protocol_buffers/runtime/field.rb
+++ b/lib/protocol_buffers/runtime/field.rb
@@ -126,7 +126,7 @@ module ProtocolBuffers
         klass.class_eval <<-EOF, __FILE__, __LINE__+1
         def #{name}
           unless @#{name}
-            @#{name} = RepeatedField.new(fields[#{tag}])
+            @#{name} = RepeatedField.new(message_fields[#{tag}])
           end
           @#{name}
         end
@@ -159,7 +159,7 @@ module ProtocolBuffers
       else
         klass.class_eval <<-EOF, __FILE__, __LINE__+1
           def #{name}=(value)
-            field = fields[#{tag}]
+            field = message_fields[#{tag}]
             if value.nil?
               @set_fields[#{tag}] = false
               @#{name} = field.default_value

--- a/lib/protocol_buffers/runtime/message.rb
+++ b/lib/protocol_buffers/runtime/message.rb
@@ -313,7 +313,7 @@ module ProtocolBuffers
     # Comparison by class and field values.
     def ==(obj)
       return false unless obj.is_a?(self.class)
-      fields.each do |tag, field|
+      message_fields.each do |tag, field|
         return false unless self.__send__(field.name) == obj.__send__(field.name)
       end
       return true
@@ -344,8 +344,14 @@ module ProtocolBuffers
     end
 
     # Returns a hash of { tag => ProtocolBuffers::Field }
-    def fields
+    def message_fields
       self.class.fields
+    end
+
+    # <b>DEPRECATED:</b> Please use <tt>message_fields</tt> instead.
+    def fields
+      warn "[DEPRECATION] `fields` is deprecated.  Please use `message_fields` instead."
+      message_fields
     end
 
     # Find the field for the given attribute name. Returns a
@@ -358,7 +364,7 @@ module ProtocolBuffers
 
     # Equivalent to fields[tag]
     def self.field_for_tag(tag)
-      fields[tag]
+      message_fields[tag]
     end
 
     # Reflection: get the attribute value for the given tag id.
@@ -367,11 +373,11 @@ module ProtocolBuffers
     #   # is equivalent to
     #   message.f1
     def value_for_tag(tag)
-      self.__send__(fields[tag].name)
+      self.__send__(message_fields[tag].name)
     end
 
     def set_value_for_tag(tag, value)
-      self.__send__("#{fields[tag].name}=", value)
+      self.__send__("#{message_fields[tag].name}=", value)
     end
 
     # Reflection: does this Message have the field set?
@@ -386,7 +392,7 @@ module ProtocolBuffers
     def inspect
       ret = ProtocolBuffers.bin_sio
       ret << "#<#{self.class.name}"
-      fields.each do |tag, field|
+      message_fields.each do |tag, field|
         if value_for_tag?(tag)
           value = field.inspect_value(self.__send__(field.name))
         else
@@ -398,7 +404,7 @@ module ProtocolBuffers
       return ret.string
     end
 
-    def merge_field(tag, value, field = fields[tag]) # :nodoc:
+    def merge_field(tag, value, field = message_fields[tag]) # :nodoc:
       if field.repeated?
         if value.is_a?(Array)
           self.__send__("#{field.name}=", self.__send__(field.name) + value)
@@ -495,7 +501,7 @@ module ProtocolBuffers
     protected
 
     def initialize_field(tag)
-      field = fields[tag]
+      field = message_fields[tag]
       new_value = field.default_value
       self.instance_variable_set("@#{field.name}", new_value)
       if field.class == Field::MessageField

--- a/spec/proto_files/name_collision.proto
+++ b/spec/proto_files/name_collision.proto
@@ -1,0 +1,9 @@
+package test;
+
+message Field {
+  required string name = 1;
+}
+
+message Message {
+  repeated Field fields = 1;
+}

--- a/spec/runtime_spec.rb
+++ b/spec/runtime_spec.rb
@@ -385,7 +385,7 @@ describe ProtocolBuffers, "runtime" do
 
     bit2 = Featureful::ABitOfEverything.parse(bit.to_s)
     bit.should == bit2
-    bit.fields.each do |tag, field|
+    bit.message_fields.each do |tag, field|
       bit.value_for_tag(tag).should == bit2.value_for_tag(tag)
     end
   end


### PR DESCRIPTION
I'm implementing a client library for Mozilla Heka, and their [message.proto](https://github.com/mozilla-services/heka/blob/master/message/message.proto) contains a `fields` field to embed more `Field` message type. Although I don't agree with their decision, the ruby client should support that format. 

When the `Message` message type compiled by `ruby-protocol-buffers` tries to initiate itself with the `fields` field in it, runs into an infinite loop. I know, the whole thing seems ridiculous.

My first proposal is to add a `message_` prefix to `fields`. If you have a better naming convention, I'll change this.
