### PR TITLE
Correctly require nested protos.

### DIFF
--- a/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
+++ b/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
@@ -24,7 +24,13 @@ require 'protocol_buffers'
 HEADER
 
     descriptor.dependency.each do |dep|
-      path = File.basename(dep, ".proto") + ".pb"
+      dir      = File.dirname(dep)
+      filename = File.basename(dep, ".proto") + ".pb"
+      path = if dir == '.'
+        filename
+      else
+        File.join(dir, filename)
+      end
       @io.write("begin; require '#{path}'; rescue LoadError; end\n")
     end
     @io.write("\n") unless descriptor.dependency.empty?

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -4,6 +4,10 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'protocol_buffers'
 require 'protocol_buffers/compiler'
 
+require 'protocol_buffers/compiler/file_descriptor_to_ruby'
+
+require 'tmpdir'
+require 'tempfile'
 describe ProtocolBuffers, "compiler" do
 
   test_files = Dir[File.join(File.dirname(__FILE__), "proto_files", "*.proto")]
@@ -13,10 +17,41 @@ describe ProtocolBuffers, "compiler" do
   end
 
   test_files.each do |file|
+    next if File.basename(file) == 'depends.proto'
+
     it "can compile #{File.basename(file)}" do
       proc do
         ProtocolBuffers::Compiler.compile_and_load(file)
       end.should_not raise_error()
+    end
+  end
+
+  it 'can compile and instantiate a proto with nested dependencies' do
+    protocfile = Tempfile.new('ruby-protoc')
+    protocfile.binmode
+
+    ProtocolBuffers::Compiler.compile(protocfile.path, %w(
+      spec/proto_files/simple.proto
+      spec/proto_files/nested/child.proto
+      spec/proto_files/depends.proto
+    ), :include_dirs => %w(spec/proto_files))
+
+
+    descriptor_set = FileDescriptorSet.parse(protocfile)
+    protocfile.close(true)
+
+    Dir.mktmpdir do |dir|
+      descriptor_set.file.each do |file|
+        name = file.name
+        path = File.join(dir, File.dirname(name), File.basename(name, '.proto') + '.pb.rb')
+        FileUtils.mkdir_p File.dirname(path)
+        File.open(path, "w") {|f|
+          FileDescriptorToRuby.new(file).write(f)
+        }
+      end
+
+      $LOAD_PATH << dir
+      load File.join(dir, 'depends.pb.rb')
     end
   end
 

--- a/spec/proto_files/depends.proto
+++ b/spec/proto_files/depends.proto
@@ -1,5 +1,8 @@
 package depends;
 
 import "simple.proto";
+import "nested/child.proto";
 
-message Depends {}
+message Depends {
+  optional nested.child.Child child_field = 1;
+}

--- a/spec/proto_files/nested/child.proto
+++ b/spec/proto_files/nested/child.proto
@@ -1,0 +1,5 @@
+package nested.child;
+
+message Child {
+  optional string test_field = 1;
+};


### PR DESCRIPTION
Sorry the spec is kind of ghetto but I couldn't figure out a good way to adapt the existing `compile_and_load`.

This is necessary because when requiring a proto that depends on nested definitions, you don't want to add every subfolder to your load path.
