### PR TITLE
Add support of groups

### DIFF
--- a/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
+++ b/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
@@ -123,6 +123,9 @@ HEADER
       message.field.each do |field|
         typename = field_typename(field)
         fieldline = %{#{LABEL_MAPPING[field.label]} #{typename}, :#{field.name}, #{field.number}}
+        if field.type == TYPE_GROUP
+          fieldline << %{, :group => true}
+        end
         if field.default_value && field.default_value != ""
           fieldline << %{, :default => #{default_value(field)}}
         end

--- a/lib/protocol_buffers/runtime/message.rb
+++ b/lib/protocol_buffers/runtime/message.rb
@@ -498,7 +498,7 @@ module ProtocolBuffers
       field = fields[tag]
       new_value = field.default_value
       self.instance_variable_set("@#{field.name}", new_value)
-      if field.class == Field::MessageField
+      if field.kind_of? Field::AggregateField
         new_value.notify_on_change(self, tag)
       end
       @set_fields[tag] = false

--- a/spec/proto_files/featureful.pb.rb
+++ b/spec/proto_files/featureful.pb.rb
@@ -20,6 +20,9 @@ module Featureful
   class A < ::ProtocolBuffers::Message
     # forward declarations
     class Sub < ::ProtocolBuffers::Message; end
+    class Group1 < ::ProtocolBuffers::Message; end
+    class Group2 < ::ProtocolBuffers::Message; end
+    class Group3 < ::ProtocolBuffers::Message; end
 
     # nested messages
     class Sub < ::ProtocolBuffers::Message
@@ -43,12 +46,54 @@ module Featureful
       optional ::Featureful::A::Sub::SubSub, :subsub1, 3
     end
 
+    class Group1 < ::ProtocolBuffers::Message
+      # forward declarations
+      class Subgroup < ::ProtocolBuffers::Message; end
+
+      # nested messages
+      class Subgroup < ::ProtocolBuffers::Message
+        required :int32, :i1, 1
+      end
+
+      required :int32, :i1, 1
+      repeated ::Featureful::A::Group1::Subgroup, :subgroup, 2, :group => true
+    end
+
+    class Group2 < ::ProtocolBuffers::Message
+      # forward declarations
+      class Subgroup < ::ProtocolBuffers::Message; end
+
+      # nested messages
+      class Subgroup < ::ProtocolBuffers::Message
+        required :int32, :i1, 1
+      end
+
+      required :int32, :i1, 1
+      repeated ::Featureful::A::Group2::Subgroup, :subgroup, 2, :group => true
+    end
+
+    class Group3 < ::ProtocolBuffers::Message
+      # forward declarations
+      class Subgroup < ::ProtocolBuffers::Message; end
+
+      # nested messages
+      class Subgroup < ::ProtocolBuffers::Message
+        required :int32, :i1, 1
+      end
+
+      required :int32, :i1, 1
+      repeated ::Featureful::A::Group3::Subgroup, :subgroup, 2, :group => true
+    end
+
     repeated :int32, :i1, 1
     optional :int32, :i2, 2
     required :int32, :i3, 3
     repeated ::Featureful::A::Sub, :sub1, 4
     optional ::Featureful::A::Sub, :sub2, 5
     required ::Featureful::A::Sub, :sub3, 6
+    repeated ::Featureful::A::Group1, :group1, 7, :group => true
+    optional ::Featureful::A::Group2, :group2, 8, :group => true
+    required ::Featureful::A::Group3, :group3, 9, :group => true
   end
 
   class B < ::ProtocolBuffers::Message

--- a/spec/proto_files/featureful.proto
+++ b/spec/proto_files/featureful.proto
@@ -25,6 +25,25 @@ message A {
   repeated Sub sub1 = 4;
   optional Sub sub2 = 5;
   required Sub sub3 = 6;
+
+  repeated group Group1 = 7 {
+    required int32 i1 = 1;
+    repeated group Subgroup = 2 {
+      required int32 i1 = 1;
+    }
+  }
+  optional group Group2 = 8 {
+    required int32 i1 = 1;
+    repeated group Subgroup = 2 {
+      required int32 i1 = 1;
+    }
+  }
+  required group Group3 = 9 {
+    required int32 i1 = 1;
+    repeated group Subgroup = 2 {
+      required int32 i1 = 1;
+    }
+  }
 };
 
 message B {

--- a/spec/runtime_spec.rb
+++ b/spec/runtime_spec.rb
@@ -135,6 +135,20 @@ describe ProtocolBuffers, "runtime" do
     a1.has_sub2?.should == true
   end
 
+  it "flags group that have been set" do
+    a1 = Featureful::A.new
+    a1.value_for_tag?(a1.class.field_for_name(:group1).tag).should == true
+    a1.value_for_tag?(a1.class.field_for_name(:group2).tag).should == false
+    a1.value_for_tag?(a1.class.field_for_name(:group3).tag).should == false
+
+    a1.has_group1?.should == true
+    a1.has_group2?.should == false
+    a1.has_group3?.should == false
+
+    a1.group2 = Featureful::A::Group2.new(:i1 => 1)
+    a1.has_group2?.should == true
+  end
+
   describe "#inspect" do
     it "should leave out un-set fields" do
       b1 = Simple::Bar.new
@@ -148,6 +162,10 @@ describe ProtocolBuffers, "runtime" do
     a1 = Featureful::A.new
     a1.has_sub2?.should == false
     a1.sub2.payload = "ohai"
+    a1.has_sub2?.should == true
+
+    a1.has_group2?.should == false
+    a1.group2.i1 = 1
     a1.has_sub2?.should == true
   end
 
@@ -609,6 +627,9 @@ describe ProtocolBuffers, "runtime" do
       f.valid?.should == false
       f.sub3.valid?.should == false
       f.sub3.payload_type = Featureful::A::Sub::Payloads::P1
+      f.valid?.should == false
+      f.group3.valid?.should == false
+      f.group3.i1 = 1
       f.valid?.should == true
       f.sub3.valid?.should == true
     end


### PR DESCRIPTION
Hello,  I would appreciate it if you accept this feature.

I am little worried about it because REAME.md says "Probably Never to be Supported" about groups.  Does it mean just you don't want to spend your time to implement the support, or you never want to support it?

I hope you meant the first one.  Thanks!

---

This commit does:
- Extends the Ruby-internal DSL for protocol buffers so that it supports
  groups.
- Lets the complier to generate the DSL for group if the field is a
  group.
- Allows the runtime to serialize and deserialize group fields
