### PR TITLE
check for protoc in path

### DIFF
--- a/bin/ruby-protoc
+++ b/bin/ruby-protoc
@@ -32,19 +32,7 @@ rest = opts.parse(ARGV)
 filenames = rest
 
 (puts "Missing input file.\n\n"; puts opts; exit) if filenames.empty?
-
-def which(cmd)
-  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
-  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-    exts.each { |ext|
-      exe = File.join(path, "#{cmd}#{ext}")
-      return exe if File.executable? exe
-    }
-  end
-  return nil
-end
-
-(puts "protoc not installed.\n"; exit) unless which("protoc")
+(puts "protoc not installed.\n"; exit) unless ProtocolBuffers::Compiler.available?
 
 protocfile = Tempfile.new("ruby-protoc")
 protocfile.binmode


### PR DESCRIPTION
For issue https://github.com/codekitchen/ruby-protocol-buffers/issues/4, copied which method from http://stackoverflow.com/questions/2108727/which-in-ruby-checking-if-program-exists-in-path-from-ruby
