### PR TITLE
remove multiple gemfiles, simplify travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: ruby
-gemfile:
-  - Gemfile
-  # i can't find a way to use the same Gemfile and just specify --without varint
-  - Gemfile.no_varint
 rvm:
   - "1.8.7"
   - "1.9.3"
@@ -12,12 +8,6 @@ rvm:
   - rbx-18mode
   - rbx-19mode
 matrix:
-  exclude:
-    # can't use the varint extension in jruby runs
-    - rvm: jruby-18mode
-      gemfile: Gemfile
-    - rvm: jruby-19mode
-      gemfile: Gemfile
   allow_failures:
     # https://github.com/rubinius/rubinius/issues/2215
     - rvm: rbx-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,14 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ruby-protocol-buffers.gemspec
 gemspec
 
-group :varint do
-  gem 'varint'
+platform :ruby do
+  group :varint do
+    gem 'varint'
+  end
+end
+
+platform :mswin do
+  group :varint do
+    gem 'varint'
+  end
 end

--- a/Gemfile.no_varint
+++ b/Gemfile.no_varint
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-
-# Specify your gem's dependencies in ruby-protocol-buffers.gemspec
-gemspec


### PR DESCRIPTION
This gets rid of the multiple gemfiles, and will also automatically install varint where it can be used. I used this technique recently for one of my gems and have it running in travis OK.
