### PR TITLE
Fix Windows line-ending issues

### DIFF
--- a/bin/protoc-gen-ruby
+++ b/bin/protoc-gen-ruby
@@ -26,5 +26,6 @@ rescue => error
   ]
   $stderr.puts response.error
 else
-  print response.to_s
+  $stdout.binmode
+  $stdout.print response.to_s
 end


### PR DESCRIPTION
On Windows, any newlines printed to $stdout are automatically converted
to "\r\n", which breaks the protocol buffer format.  Switching $stdout to
binary mode immediately before printing the file prevents this from
happening.
