### PR TITLE
Capitalise first letter of enum names in defaults

### DIFF
--- a/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
+++ b/lib/protocol_buffers/compiler/file_descriptor_to_ruby.rb
@@ -198,7 +198,7 @@ HEADER
       field.default_value
     when TYPE_ENUM
       typename = field_typename(field)
-      %{#{typename}::#{field.default_value}}
+      %{#{typename}::#{capfirst(field.default_value)}}
     else
       field.default_value
     end


### PR DESCRIPTION
When defining the enums themselves, the first letter is capitalised in
order to create a constant named after the enum, however if a message
containing that enum has a default value set, the first letter of *that*
wasn't being capitalised, causing an error.  This commit ensures that
both are capitalised.