### PR TITLE
Fix repeated fields with ruby keyword names.

### DIFF
--- a/lib/protocol_buffers/runtime/field.rb
+++ b/lib/protocol_buffers/runtime/field.rb
@@ -153,10 +153,10 @@ module ProtocolBuffers
         klass.class_eval <<-EOF, __FILE__, __LINE__+1
           def #{name}=(__value)
             if __value.nil?
-              #{name}.clear
+              self.#{name}.clear
             else
-              unless __value.equal?(#{name})
-                #{name}.clear
+              unless __value.equal?(self.#{name})
+                self.#{name}.clear
                 __value.each { |i| @#{name}.push i }
               end
               if @parent_for_notify
@@ -610,7 +610,7 @@ module ProtocolBuffers
 
       def text_format(io, value, options = nil)
         formatted = @value_to_name[value] || value.to_s
-        io.write formatted 
+        io.write formatted
       end
     end
 

--- a/spec/proto_files/featureful.pb.rb
+++ b/spec/proto_files/featureful.pb.rb
@@ -12,6 +12,7 @@ module Featureful
   class D < ::ProtocolBuffers::Message; end
   class E < ::ProtocolBuffers::Message; end
   class F < ::ProtocolBuffers::Message; end
+  class Keywords < ::ProtocolBuffers::Message; end
 
   # enums
   module MainPayloads
@@ -174,6 +175,13 @@ module Featureful
     set_fully_qualified_name "featureful.F"
 
     optional :string, :s, 1
+  end
+
+  class Keywords < ::ProtocolBuffers::Message
+    set_fully_qualified_name "featureful.Keywords"
+
+    repeated :bool, :or, 1
+    optional :bool, :and, 2
   end
 
 end

--- a/spec/proto_files/featureful.proto
+++ b/spec/proto_files/featureful.proto
@@ -91,3 +91,8 @@ message E {
 message F {
   optional string s = 1;
 }
+
+message Keywords {
+  repeated bool or = 1;
+  optional bool and = 2;
+}

--- a/spec/runtime_spec.rb
+++ b/spec/runtime_spec.rb
@@ -952,6 +952,14 @@ describe ProtocolBuffers, "runtime" do
     Services::NoNameFooBarService.fully_qualified_name.should == nil
   end
 
+  it "correctly handles fields with keyword names" do
+    f = Featureful::Keywords.new(
+      :or => [true],
+      :and => false,
+    )
+    f.or.should =~ [true]
+  end
+
   def get_rpcs
     Services::FooBarService.rpcs.size.should == 2
     first_rpc = Services::FooBarService.rpcs[0]


### PR DESCRIPTION
The field related runtime code generation was producing invalid
code if you had a repeated field named e.g. "or". I added a
"self." to disambiguate (e.g. "or.clear" became "self.or.clear").