### PR TITLE
Precompute immutable fields

### DIFF
--- a/lib/protocol_buffers/runtime/field.rb
+++ b/lib/protocol_buffers/runtime/field.rb
@@ -96,8 +96,9 @@ module ProtocolBuffers
   class Field # :nodoc: all
     attr_reader :otype, :name, :tag
 
-    def repeated?; otype == :repeated end
-    def packed?; repeated? && @opts[:packed] end
+    def repeated?; @repeated; end
+    def packed?; @packed; end
+    def required?; @required; end
 
     def self.create(sender, otype, type, name, tag, opts = {})
       if type.is_a?(Symbol)
@@ -123,6 +124,9 @@ module ProtocolBuffers
       @name = name
       @tag = tag
       @opts = opts.dup
+      @repeated = otype == :repeated
+      @required = otype == :required
+      @packed = @repeated && opts[:packed]
     end
 
     def add_reader_to(klass)

--- a/lib/protocol_buffers/runtime/message.rb
+++ b/lib/protocol_buffers/runtime/message.rb
@@ -573,7 +573,7 @@ module ProtocolBuffers
       return true unless @has_required_field
 
       fields.each do |tag, field|
-        next if field.otype != :required
+        next unless field.required?
         next if message.value_for_tag?(tag) && (field.class != Field::MessageField || message.value_for_tag(tag).valid?)
         return false unless raise_exception
         raise(ProtocolBuffers::EncodeError.new(field), "Required field '#{field.name}' is invalid")


### PR DESCRIPTION
This change is related to https://github.com/codekitchen/ruby-protocol-buffers/pull/44. After removing LimitedIO, packed? and required? are the next decoding bottlenecks. This change precomputes these methods, and the required attribute for consistency, because they are called frequently and are immutable.

This PR further improves decoding performance by approximately 10%.